### PR TITLE
Allow <mj-raw> inside <mj-list> to be used e.g. with template engines.

### DIFF
--- a/components/MjLi.js
+++ b/components/MjLi.js
@@ -6,7 +6,7 @@ export default class MjLi extends BodyComponent {
 
   static dependencies = {
     'mj-li': [],
-    'mj-list': ['mj-li'],
+    'mj-list': ['mj-li', 'mj-raw'],
   }
 
   static allowedAttributes = {

--- a/components/MjList.js
+++ b/components/MjList.js
@@ -4,7 +4,7 @@ export default class MjList extends BodyComponent {
   static componentName = 'mj-list'
 
   static dependencies = {
-    'mj-list': ['mj-li'],
+    'mj-list': ['mj-li', 'mj-raw'],
     'mj-column': ['mj-list'],
   }
 

--- a/lib/MjLi.js
+++ b/lib/MjLi.js
@@ -253,7 +253,7 @@ _defineProperty(MjLi, 'endingTag', true)
 
 _defineProperty(MjLi, 'dependencies', {
   'mj-li': [],
-  'mj-list': ['mj-li'],
+  'mj-list': ['mj-li', 'mj-raw'],
 })
 
 _defineProperty(MjLi, 'allowedAttributes', {

--- a/lib/MjList.js
+++ b/lib/MjList.js
@@ -205,7 +205,7 @@ exports['default'] = MjList
 _defineProperty(MjList, 'componentName', 'mj-list')
 
 _defineProperty(MjList, 'dependencies', {
-  'mj-list': ['mj-li'],
+  'mj-list': ['mj-li', 'mj-raw'],
   'mj-column': ['mj-list'],
 })
 


### PR DESCRIPTION
## Pull Request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently it is not possible to use <mj-raw> inside of <mj-list>. This is needed for template engines to e.g. surround single <mj-li> with conditions. Without <mj-raw>, those conditions get stripped out when run through MJML.

Issue Number: #12 

## What is the new behavior?

<mj-raw> is now allowed to be used inside <mj-list>.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This PR does not change the visual presentation of the components.
